### PR TITLE
fix: disabled databases included in the count

### DIFF
--- a/src/lib/server/backups/run-backup-job.ts
+++ b/src/lib/server/backups/run-backup-job.ts
@@ -40,6 +40,10 @@ export async function runBackupJob(jobId: number, forcedDatabases: number[] | nu
 
         const res = await jobDatabaseBackup(job, i, run.id, forcedDatabases !== null);
 
+        if (res.isOk() && res.value[0] === null) {
+            continue; // Skip if the database was disabled in the job
+        }
+
         totalBackupsCount++;
         if (res.isOk()) {
             successfulBackupsCount++;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Disabled databases are now fully skipped during backup runs, preventing inflated totals for backups and pruned snapshots.
  - Backup metrics and reports now accurately reflect only processed databases.

- Performance
  - Per-database delays are skipped for disabled databases, reducing overall backup job duration when many databases are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->